### PR TITLE
3.0.5: quiet missing-attribute --get warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ or terminal:
 
 ```bash
 cabinet -g employee Tyler salary
+# Dotted paths work too (expanded to nested keys):
+cabinet -g employee.Tyler.salary
 ```
 
 - optional: `--force-cache-update` to force a cache update

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinet
-version = 1!3.0.4
+version = 1!3.0.5
 author = Tyler Woodfin
 author_email = feedback-cabinet@tyler.cloud
 description = Easily manage data storage and logging across repos

--- a/src/cabinet/cabinet.py
+++ b/src/cabinet/cabinet.py
@@ -57,6 +57,34 @@ from .mail import Mail
 from . import log as log_module
 
 
+def _expand_dotted_path(parts: list[str] | tuple[str, ...]) -> list[str]:
+    """
+    Expand CLI path segments so ``taiga.api_root`` becomes ``['taiga', 'api_root']``.
+
+    Empty segments from consecutive or trailing dots are dropped.
+    """
+    expanded: list[str] = []
+    for part in parts:
+        if not isinstance(part, str):
+            expanded.append(part)
+            continue
+        if "." in part:
+            expanded.extend(segment for segment in part.split(".") if segment)
+        else:
+            expanded.append(part)
+    return expanded
+
+
+def _warn_missing_attribute(attribute: str) -> None:
+    """
+    Tell the operator a key was missing without writing a WARNING to log files / Loki.
+
+    Exploratory ``cabinet --get`` and optional-key lookups are normal; they should not
+    show up as warnings in Grafana.
+    """
+    print(f"WARNING: Attribute '{attribute}' is missing", file=sys.stderr)
+
+
 class Cabinet:
     """
     Cabinet class
@@ -993,7 +1021,9 @@ class Cabinet:
 
         Args:
             *attributes (str): A sequence of strings representing nested attributes.
-            warn_missing (bool, optional): Whether to warn if an attribute is missing.
+            warn_missing (bool, optional): Whether to print a stderr warning if an
+                attribute is missing. Does **not** write a WARNING log line (avoids
+                Loki noise from routine ``--get`` probes). Defaults to False.
             is_print (bool, optional): Whether to print the return value.
             force_cache_update (bool, optional): For MongoDB. Whether to force a fresh MongoDB call.
             return_type (Type[T], optional): The expected return type of the result.
@@ -1018,9 +1048,7 @@ class Cabinet:
                         result = result[attribute]
                     else:
                         if warn_missing:
-                            self.log(
-                                f"Attribute '{attribute}' is missing", level="warn"
-                            )
+                            _warn_missing_attribute(attribute)
                         return None
 
                 if is_print:
@@ -1056,7 +1084,7 @@ class Cabinet:
                     result = result[attribute]
                 else:
                     if warn_missing:
-                        self.log(f"Attribute '{attribute}' is missing", level="warn")
+                        _warn_missing_attribute(attribute)
                     return None
 
             if isinstance(result, str):
@@ -1086,7 +1114,10 @@ class Cabinet:
             storage_type: str = (
                 "cache or MongoDB" if self.mongodb_enabled else "local storage"
             )
-            self.log(f"'{attributes}' not found in {storage_type}", level="warn")
+            print(
+                f"WARNING: '{attributes}' not found in {storage_type}",
+                file=sys.stderr,
+            )
         return None
 
     def remove(self, *attribute: str, is_print: bool = False):
@@ -1585,7 +1616,11 @@ def main():
         help="(for -ef) Do not create file if it does not exist",
     )
     parser.add_argument(
-        "--get", "-g", dest="get", nargs="+", help="Get a property from MongoDB"
+        "--get",
+        "-g",
+        dest="get",
+        nargs="+",
+        help="Get a property (space- or dot-separated path, e.g. taiga api_root)",
     )
     parser.add_argument(
         "--put",
@@ -1740,17 +1775,19 @@ def main():
             is_print=True,
             warn_missing=True,
             force_cache_update=args.force_cache_update,
-            *args.get,
+            *_expand_dotted_path(args.get),
         )
     elif args.put:
-        attribute_values = args.put
-        cab.put(*attribute_values, is_print=True)
+        # Expand dotted path keys only; leave the final value intact (may contain dots).
+        *path_parts, value = args.put
+        put_args = _expand_dotted_path(path_parts) + [value]
+        cab.put(*put_args, is_print=True)
     elif args.append:
-        attribute_values = args.append
-        cab.append(*attribute_values, is_print=True)
+        *path_parts, value = args.append
+        append_args = _expand_dotted_path(path_parts) + [value]
+        cab.append(*append_args, is_print=True)
     elif args.remove:
-        attribute_values = args.remove
-        cab.remove(*attribute_values, is_print=True)
+        cab.remove(*_expand_dotted_path(args.remove), is_print=True)
     elif args.get_file:
         cab.get_file_as_array(file_name=args.get_file, file_path="", strip=args.strip)
     elif args.log:

--- a/tests/test_get_missing.py
+++ b/tests/test_get_missing.py
@@ -1,0 +1,52 @@
+"""Tests for get() missing-attribute handling and dotted CLI paths."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr
+from unittest.mock import MagicMock
+
+from cabinet.cabinet import Cabinet, _expand_dotted_path
+
+
+def test_expand_dotted_path_splits_segments():
+    assert _expand_dotted_path(["taiga.api_root"]) == ["taiga", "api_root"]
+    assert _expand_dotted_path(["taiga", "api_root"]) == ["taiga", "api_root"]
+    assert _expand_dotted_path(["a.b", "c"]) == ["a", "b", "c"]
+    assert _expand_dotted_path(["a..b."]) == ["a", "b"]
+
+
+def test_get_warn_missing_prints_stderr_without_log(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("{}", encoding="utf-8")
+
+    cab = Cabinet()
+    cab.mongodb_enabled = False
+    cab.path_file_data = str(data_file)
+    cab.log = MagicMock()
+
+    err = io.StringIO()
+    with redirect_stderr(err):
+        result = cab.get("github", warn_missing=True)
+
+    assert result is None
+    assert "Attribute 'github' is missing" in err.getvalue()
+    cab.log.assert_not_called()
+
+
+def test_get_missing_silent_by_default(tmp_path):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("{}", encoding="utf-8")
+
+    cab = Cabinet()
+    cab.mongodb_enabled = False
+    cab.path_file_data = str(data_file)
+    cab.log = MagicMock()
+
+    err = io.StringIO()
+    with redirect_stderr(err):
+        result = cab.get("github")
+
+    assert result is None
+    assert err.getvalue() == ""
+    cab.log.assert_not_called()


### PR DESCRIPTION
## Summary
- `get(..., warn_missing=True)` prints to stderr but no longer writes WARNING log lines (was filling Loki from agent `cabinet --get` probes)
- CLI accepts dotted paths (`cabinet -g taiga.api_root`) by expanding to nested keys
- Bump to 1!3.0.5

## Test plan
- [ ] `cabinet -g github` prints WARNING on stderr; `cabinet --query --query-level warning --query-message github` count does not increase
- [ ] `cabinet -g taiga.api_root` returns the nested value
- [ ] `pytest tests/test_get_missing.py`
