### PR TITLE
3.0.6: fix CI tests for missing-attribute get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+# Run the same install/test/build path as the PyPI release, before merge.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  package-build:
+    uses: ./.github/workflows/package-build.yml

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -1,0 +1,48 @@
+# Shared package build used by PR CI and the main release workflow.
+# Keep publish/tag steps only in release.yml.
+name: Package build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      # Match a clean runner (no ~/.config/cabinet) so interactive setup cannot hide failures.
+      - name: Install package and run tests
+        env:
+          HOME: ${{ runner.temp }}/cabinet-home
+        run: |
+          mkdir -p "$HOME"
+          pip install -e ".[dev]"
+          pytest tests/ -v
+
+      - name: Install build tools
+        run: pip install pex build twine
+
+      - name: Build Pex file
+        run: pex . -o cabinet.pex --script=cabinet
+
+      - name: Build PyPI package
+        run: python -m build
+
+      - name: Check PyPI package with twine
+        run: python -m twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cabinet-dist
+          path: |
+            dist/
+            cabinet.pex
+          if-no-files-found: error

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -39,7 +39,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cabinet-dist
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,73 +9,63 @@ on:
       - main
 
 jobs:
-  build-and-release:
+  # Same install, test, pex, and `python -m build` path as PR CI.
+  package-build:
+    uses: ./.github/workflows/package-build.yml
+
+  publish:
+    needs: package-build
     runs-on: ubuntu-latest
-
     steps:
-    # Checkout the repository
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Set up Python
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
 
-    - name: Install package and run tests
-      run: |
-        pip install -e ".[dev]"
-        pytest tests/ -v
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cabinet-dist
 
-    # Install Pex
-    - name: Install Pex
-      run: pip install pex build twine
-
-    # Build Pex file
-    - name: Build Pex file
-      run: pex . -o cabinet.pex --script=cabinet
-
-    # Build PyPI package
-    - name: Build PyPI package
-      run: python -m build
-
-    # Create and push tag (before PyPI so a publish always has a corresponding tag)
-    - name: Create and push tag
-      id: create_tag
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        VERSION=$(grep -oP '^version\s*=\s*\K.+' setup.cfg)
-        TAG="v$VERSION"
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-        git fetch --tags --quiet origin 2>/dev/null || true
-        if git show-ref --verify --quiet "refs/tags/$TAG"; then
-          echo "Skipping tag create/push: $TAG already exists (same version as a previous release)."
+      - name: Create and push tag
+        id: create_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep -oP '^version\s*=\s*\K.+' setup.cfg)
+          TAG="v$VERSION"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git fetch --tags --quiet origin 2>/dev/null || true
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            echo "Skipping tag create/push: $TAG already exists (same version as a previous release)."
+            echo "tag=$TAG" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
+            echo "Skipping tag push: origin already has $TAG; not creating a duplicate."
+            echo "tag=$TAG" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/tylerjwoodfin/cabinet.git "$TAG"
           echo "tag=$TAG" >> "$GITHUB_ENV"
-          exit 0
-        fi
-        if [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
-          echo "Skipping tag push: origin already has $TAG; not creating a duplicate."
-          echo "tag=$TAG" >> "$GITHUB_ENV"
-          exit 0
-        fi
-        git tag "$TAG"
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/tylerjwoodfin/cabinet.git "$TAG"
-        echo "tag=$TAG" >> "$GITHUB_ENV"
 
-    # Publish to PyPI
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: python -m twine upload dist/* --verbose
+      - name: Install twine
+        run: pip install twine
 
-    # Upload Pex file to GitHub Releases
-    - name: Upload Pex file to GitHub Releases
-      uses: ncipollo/release-action@v1
-      with:
-        tag: ${{ env.tag }}
-        artifacts: cabinet.pex
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: python -m twine upload dist/* --verbose
+
+      - name: Upload Pex file to GitHub Releases
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.tag }}
+          artifacts: cabinet.pex
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cabinet-dist
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinet
-version = 1!3.0.5
+version = 1!3.0.6
 author = Tyler Woodfin
 author_email = feedback-cabinet@tyler.cloud
 description = Easily manage data storage and logging across repos

--- a/tests/test_get_missing.py
+++ b/tests/test_get_missing.py
@@ -3,10 +3,29 @@
 from __future__ import annotations
 
 import io
+import json
 from contextlib import redirect_stderr
 from unittest.mock import MagicMock
 
 from cabinet.cabinet import Cabinet, _expand_dotted_path
+
+
+def _local_cab(tmp_path, data: dict) -> Cabinet:
+    """Build a Cabinet without reading ~/.config (CI has no interactive config)."""
+    cab_dir = tmp_path / ".cabinet"
+    cab_dir.mkdir()
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    data_file = cab_dir / "data.json"
+    data_file.write_text(json.dumps(data), encoding="utf-8")
+
+    cab = Cabinet.__new__(Cabinet)
+    cab.mongodb_enabled = False
+    cab.path_file_data = str(data_file)
+    cab.path_dir_log = str(log_dir)
+    cab.cached_data = []
+    cab.update_cache = lambda: None  # noqa: ARG005
+    return cab
 
 
 def test_expand_dotted_path_splits_segments():
@@ -16,13 +35,8 @@ def test_expand_dotted_path_splits_segments():
     assert _expand_dotted_path(["a..b."]) == ["a", "b"]
 
 
-def test_get_warn_missing_prints_stderr_without_log(tmp_path, monkeypatch):
-    data_file = tmp_path / "data.json"
-    data_file.write_text("{}", encoding="utf-8")
-
-    cab = Cabinet()
-    cab.mongodb_enabled = False
-    cab.path_file_data = str(data_file)
+def test_get_warn_missing_prints_stderr_without_log(tmp_path):
+    cab = _local_cab(tmp_path, {})
     cab.log = MagicMock()
 
     err = io.StringIO()
@@ -35,12 +49,7 @@ def test_get_warn_missing_prints_stderr_without_log(tmp_path, monkeypatch):
 
 
 def test_get_missing_silent_by_default(tmp_path):
-    data_file = tmp_path / "data.json"
-    data_file.write_text("{}", encoding="utf-8")
-
-    cab = Cabinet()
-    cab.mongodb_enabled = False
-    cab.path_file_data = str(data_file)
+    cab = _local_cab(tmp_path, {})
     cab.log = MagicMock()
 
     err = io.StringIO()


### PR DESCRIPTION
## Summary
- Fix `tests/test_get_missing.py` to avoid `Cabinet()` interactive setup (broke release CI on runners with no `~/.config/cabinet`)
- Bump to 1!3.0.6 so PyPI/tag can publish after the failed 3.0.5 release run

## Test plan
- [ ] `HOME=/tmp/empty pytest tests/ -q` passes
- [ ] Release workflow publishes tag + PyPI after merge
