### PR TITLE
TJW-332: Log SMTP send attempts at debug

### DIFF
--- a/src/cabinet/mail.py
+++ b/src/cabinet/mail.py
@@ -275,7 +275,7 @@ class Mail:
             try:
                 self.cab.log(
                     f"SMTP send attempt {attempt}/{max_attempts} for {subject!r}",
-                    level="info",
+                    level="debug",
                 )
                 server = self._connect_smtp(timeout)
                 self.cab.log(


### PR DESCRIPTION
## Summary
- Change SMTP `send attempt N/M` logging from `info` to `debug`.

## Test plan
- [ ] Send an email via Cabinet/remindmail and confirm attempt lines are no longer INFO in cabinet logs


Made with [Cursor](https://cursor.com)